### PR TITLE
Complementing tests for autobalance

### DIFF
--- a/src/components/common/BalanceChannelsButton.spec.tsx
+++ b/src/components/common/BalanceChannelsButton.spec.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Status } from 'shared/types';
+import { getNetwork, renderWithProviders } from 'utils/tests';
+import BalanceChannelsButton from './BalanceChannelsButton';
+import { fireEvent } from '@testing-library/react';
+import { initChartFromNetwork } from 'utils/chart';
+
+describe('BalanceChannelsButton', () => {
+  let unmount: () => void;
+
+  const renderComponent = () => {
+    const network = getNetwork(1, 'test network', Status.Started);
+
+    const initialState = {
+      network: {
+        networks: [network],
+      },
+      designer: {
+        activeId: 1,
+        allCharts: {
+          1: initChartFromNetwork(network),
+        },
+      },
+    };
+
+    const cmp = <BalanceChannelsButton network={network} />;
+    const result = renderWithProviders(cmp, { initialState });
+    unmount = result.unmount;
+    return result;
+  };
+
+  afterEach(() => unmount());
+
+  it('should render the button', async () => {
+    const mockChannelInfo = {
+      uniqueId: 'channel1',
+      id: 'channel1',
+      to: 'node2',
+      from: 'node1',
+      localBalance: '1000',
+      remoteBalance: '2000',
+      nextLocalBalance: 1000,
+      pending: false,
+      channelPoint: '',
+      pubkey: '',
+      capacity: '',
+      status: 'Open' as const,
+      isPrivate: false,
+    };
+    const { getByRole, store } = renderComponent();
+    store.getActions().lightning.setChannelsInfo([mockChannelInfo]);
+    const btn = getByRole('balance-channels');
+    expect(btn).toBeInTheDocument();
+
+    fireEvent.click(btn);
+    expect(store.getState().modals.balanceChannels.visible).toBe(true);
+  });
+});

--- a/src/components/common/BalanceChannelsButton.tsx
+++ b/src/components/common/BalanceChannelsButton.tsx
@@ -30,7 +30,7 @@ const BalanceChannelsButton: React.FC<Props> = ({ network }) => {
   return (
     channelsInfo.length > 0 && (
       <Tooltip title={l('btn')}>
-        <Styled.Button onClick={showModal}>
+        <Styled.Button onClick={showModal} role="balance-channels">
           <SwapOutlined />
         </Styled.Button>
       </Tooltip>

--- a/src/components/common/BalanceChannelsModal.spec.tsx
+++ b/src/components/common/BalanceChannelsModal.spec.tsx
@@ -100,13 +100,12 @@ describe('BalanceChannelsModal', () => {
     expect(store.getState().lightning.channelsInfo[0].nextLocalBalance).toBe(5000);
   });
 
-  // it('should call updateBalanceOfChannels when update button is clicked', async () => {
-  //   const { getByText, store } = await renderComponent();
-  //   const btn = getByText('Update Channels');
-  //   fireEvent.click(btn);
-
-  //   expect(store.getActions().lightning.updateBalanceOfChannels).toHaveBeenCalled();
-  // });
+  it('should call updateBalanceOfChannels when update button is clicked', async () => {
+    const { getByText } = await renderComponent();
+    const btn = getByText('Update Channels');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+  });
 
   // it('should update balance of channels and hide modal', async () => {
   //   const { store, network } = await renderComponent();

--- a/src/components/common/BalanceChannelsModal.tsx
+++ b/src/components/common/BalanceChannelsModal.tsx
@@ -6,6 +6,7 @@ import { useStoreActions, useStoreState } from 'store';
 import { ChannelInfo, Network } from 'types';
 import { format } from 'utils/units';
 import styled from '@emotion/styled';
+import { useAsyncCallback } from 'react-async-hook';
 
 interface Props {
   network: Network;
@@ -29,13 +30,23 @@ const BalanceChannelsModal: React.FC<Props> = ({ network }) => {
     updateBalanceOfChannels,
   } = useStoreActions(s => s.lightning);
 
+  const { notify } = useStoreActions(s => s.app);
+
+  const updateBalanceOfChannelsAsync = useAsyncCallback(async () => {
+    try {
+      await updateBalanceOfChannels(network);
+    } catch (error: any) {
+      notify({ message: 'Failed to update channel balance', error });
+    }
+  });
+
   return (
     <Modal
       title="Balance Channels"
       open={visible}
       okText={l('update')}
       cancelText={l('close')}
-      onOk={() => updateBalanceOfChannels(network)}
+      onOk={updateBalanceOfChannelsAsync.execute}
       onCancel={() => hideBalanceChannels()}
     >
       {/* sliders */}

--- a/src/store/models/lightning.spec.ts
+++ b/src/store/models/lightning.spec.ts
@@ -328,6 +328,11 @@ describe('Lightning Model', () => {
     manualBalanceChannelsInfo({ value: 500000, index: 0 });
     const { channelsInfo } = store.getState().lightning;
     expect(channelsInfo[0].nextLocalBalance).toBe(500000);
+
+    // Now update with non-existing index
+    manualBalanceChannelsInfo({ value: 500000, index: 999 });
+    expect(channelsInfo[0].nextLocalBalance).toBe(500000);
+    expect(channelsInfo).toHaveLength(1);
   });
 
   it('should auto balance channels', () => {

--- a/src/store/models/lightning.spec.ts
+++ b/src/store/models/lightning.spec.ts
@@ -22,6 +22,7 @@ import designerModel from './designer';
 import lightningModel from './lightning';
 import networkModel from './network';
 import modalsModel from './modals';
+import * as networkUtils from 'utils/network';
 
 jest.mock('utils/async');
 const asyncUtilMock = asyncUtil as jest.Mocked<typeof asyncUtil>;
@@ -386,6 +387,110 @@ describe('Lightning Model', () => {
       expect(notifySpy).toHaveBeenCalledWith({
         message: 'Channels balanced!',
       });
+    });
+  });
+
+  describe('balanceChannels', () => {
+    beforeEach(() => {
+      const network = getNetwork();
+      const lnNodes = network.nodes.lightning;
+      lightningServiceMock.getChannels.mockResolvedValue([
+        {
+          pending: false,
+          uniqueId: 'channel2',
+          channelPoint: 'point2',
+          pubkey: 'pubkey2',
+          capacity: '1000',
+          localBalance: '800',
+          remoteBalance: '1000',
+          status: 'Open' as const,
+          isPrivate: false,
+        },
+      ]);
+
+      const linksMock = {
+        channel1: {
+          id: 'channel1',
+          from: { nodeId: 'node1', portId: 'port1' },
+          to: { nodeId: 'node2', portId: 'port2' },
+        },
+      };
+
+      store.getState().designer.activeChart.links = linksMock;
+
+      // Mock getInvoicePayload
+      jest.spyOn(networkUtils, 'getInvoicePayload').mockReturnValue({
+        amount: 100,
+        source: lnNodes[0],
+        target: lnNodes[1],
+      });
+
+      jest
+        .spyOn(store.getActions().lightning, 'createInvoice')
+        .mockResolvedValue('invoice123');
+      jest.spyOn(store.getActions().lightning, 'payInvoice').mockResolvedValue({} as any);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should throw error if network not found', async () => {
+      const { balanceChannels } = store.getActions().lightning;
+      await expect(
+        balanceChannels({
+          id: 999,
+          toPay: [{ channelId: 'channel1', nextLocalBalance: 1500 }],
+        }),
+      ).rejects.toThrow('networkByIdErr');
+    });
+
+    it('should process channels that need balancing', async () => {
+      const network = getNetwork();
+      const { balanceChannels } = store.getActions().lightning;
+      await balanceChannels({
+        id: network.id,
+        toPay: [{ channelId: 'channel1', nextLocalBalance: 1500 }],
+      });
+
+      expect(store.getActions().lightning.createInvoice).toHaveBeenCalledTimes(1);
+      expect(store.getActions().lightning.payInvoice).toHaveBeenCalledTimes(1);
+
+      // Now we override the getInvoicePayload to return a different amount
+      // Amount that is less than `minimumSatsDiffence` and test for early return
+      const lnNodes = network.nodes.lightning;
+      jest.spyOn(networkUtils, 'getInvoicePayload').mockReturnValue({
+        amount: 40,
+        source: lnNodes[0],
+        target: lnNodes[1],
+      });
+
+      await balanceChannels({
+        id: network.id,
+        toPay: [{ channelId: 'channel1', nextLocalBalance: 1500 }],
+      });
+
+      expect(store.getActions().lightning.createInvoice).toHaveBeenCalledTimes(1);
+      expect(store.getActions().lightning.payInvoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return early if to.nodeId is not defined', async () => {
+      store.getState().designer.activeChart.links = {
+        channel1: {
+          id: 'channel1',
+          from: { nodeId: 'node1', portId: 'port1' },
+          to: { nodeId: '', portId: 'port2' },
+        },
+      };
+
+      const { balanceChannels } = store.getActions().lightning;
+      await balanceChannels({
+        id: network.id,
+        toPay: [{ channelId: 'channel1', nextLocalBalance: 1500 }],
+      });
+
+      expect(store.getActions().lightning.createInvoice).not.toHaveBeenCalled();
+      expect(store.getActions().lightning.payInvoice).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/models/lightning.spec.ts
+++ b/src/store/models/lightning.spec.ts
@@ -297,6 +297,29 @@ describe('Lightning Model', () => {
         nextLocalBalance: 1000,
       },
     ]);
+
+    store.getState().designer.activeChart.links = {
+      channel10: {
+        id: 'channel100',
+        from: { nodeId: 'node1', portId: 'port1' },
+        to: { nodeId: 'node2', portId: 'port2' },
+      },
+    };
+
+    await resetChannelsInfo(network);
+    expect(channelsInfo).toHaveLength(4);
+
+    // Test with a link that has no valid nodeid,
+    // this should early return.
+    store.getState().designer.activeChart.links = {
+      channel1: {
+        id: 'channel1',
+        from: { nodeId: 'node1', portId: 'port1' },
+        to: { nodeId: '', portId: 'port2' },
+      },
+    };
+    await resetChannelsInfo(network);
+    expect(channelsInfo).toHaveLength(4);
   });
 
   it('should manually balance channel', () => {

--- a/src/store/models/lightning.ts
+++ b/src/store/models/lightning.ts
@@ -410,9 +410,6 @@ const lightningModel: LightningModel = {
   }),
   autoBalanceChannelsInfo: action(state => {
     const { channelsInfo } = state;
-    if (!channelsInfo) {
-      return;
-    }
     for (let index = 0; index < channelsInfo.length; index += 1) {
       const { localBalance, remoteBalance } = channelsInfo[index];
       const halfAmount = Math.floor((Number(localBalance) + Number(remoteBalance)) / 2);
@@ -425,8 +422,6 @@ const lightningModel: LightningModel = {
       const { notify } = getStoreActions().app;
       const { hideBalanceChannels } = getStoreActions().modals;
       const { channelsInfo } = getState();
-
-      if (!channelsInfo) return;
 
       const toPay: PreInvoice[] = channelsInfo
         .filter(c => Number(c.localBalance) !== c.nextLocalBalance)


### PR DESCRIPTION
This PR introduces the remaining tests for the `autobalance` feature. 

There is a total of 9 commits in this PR, this is intended for the following reasons:
1. To make it easier to review and test independently
2. Makes it easier to squash the changes into existing, related commits

A breakdown of the commits:
- The first two (842b1bce861d0f1f8a6b40152a158c66b854ca9f & e460547cd25af7b4c51482aa669f642e5e9e3036) refactors the `BalanceChannelsButton` component and make it easier to test, then adds a test file for it.

- The next two commits (cea9cade549dfae53a8dd38fb3904a22657277c3 & 9aaa4bc7cce2f2136524fbe8fe8068c5bd3f9c1e) also refactor and test the `updateBalanceOfChannels` fn call.

- The next 5 commits then refactor `lightning.ts`, and add tests to previously uncovered blocks of code.

So, the way I see this, some of the commits will eventually get squashed into existing related commits in this branch. So feel free to reach out if you have any questions :) 

Btw Good Job working on this! Keep building :1st_place_medal: 


